### PR TITLE
Verify slot website

### DIFF
--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -197,7 +197,7 @@ async function verifyWebsite(req, res) {
 			issues.push('SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED')
 		}
 
-		return { hostname, issues }
+		return res.status(200).send({ hostname, issues })
 	} catch (err) {
 		console.error('Error verifyWebsite', err)
 		return res.status(500).send(err.toString())

--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -70,10 +70,10 @@ async function getAdSlots(req, res) {
 		const websitesCol = db.getMongo().collection('websites')
 		const websitesRes = await websitesCol.find(websitesQuery).toArray()
 
-		const websites = websitesRes.reduce((all, ws) => {
-			all[ws.hostname] = { issues: getWebsiteIssues(ws) }
-			return all
-		}, {})
+		const websites = websitesRes.map(ws => ({
+			id: ws.hostname,
+			issues: getWebsiteIssues(ws),
+		}))
 
 		return res.send({ slots, websites })
 	} catch (err) {

--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -193,9 +193,6 @@ async function verifyWebsite(req, res) {
 		if (!data.verifiedOwnership) {
 			issues.push('SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED')
 		}
-		if (!data.verifiedOwnership) {
-			issues.push('SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED')
-		}
 
 		return res.status(200).send({ hostname, issues })
 	} catch (err) {

--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -185,13 +185,33 @@ async function verifyWebsite(req, res) {
 
 		const issues = []
 		if (data.blacklisted) {
-			issues.push('SLOT_ISSUE_BLACKLISTED')
+			issues.push({ label: 'SLOT_ISSUE_BLACKLISTED' })
 		}
 		if (!data.verifiedIntegration) {
-			issues.push('SLOT_ISSUE_INTEGRATION_NOT_VERIFIED')
+			issues.push({
+				label: 'SLOT_ISSUE_INTEGRATION_NOT_VERIFIED',
+				args: [
+					{
+						type: 'anchor',
+						label: 'HERE',
+						href:
+							'https://help.adex.network/hc/en-us/articles/360012022820-How-to-implement-an-ad-slot-to-your-website',
+					},
+				],
+			})
 		}
 		if (!data.verifiedOwnership) {
-			issues.push('SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED')
+			issues.push({
+				label: 'SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED',
+				args: [
+					{
+						type: 'anchor',
+						label: 'HERE',
+						href:
+							'https://help.adex.network/hc/en-us/articles/360012481519-How-to-add-DNS-TXT-record-for-your-publisher-domain',
+					},
+				],
+			})
 		}
 
 		return res.status(200).send({ hostname, issues })

--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -243,7 +243,7 @@ function getWebsiteIssues(data, existingFromOthers) {
 	if (!data.verifiedOwnership) {
 		issues.push('SLOT_ISSUE_OWNERSHIP_NOT_VERIFIED')
 	}
-	if (existingFromOthers && existingFromOthers.lehgt) {
+	if (existingFromOthers && existingFromOthers.length) {
 		issues.push('SLOT_ISSUE_SOMEONE_ELSE_VERIFIED')
 	}
 


### PR DESCRIPTION
* verify website on slot create #86 
* return websites with issues on getting user slots
* `/slots/verify-website` route that returns website `hostname` and `issues` - used in platform to get issues before the slot is created. This does not update the `websites` collection
* `/slots` route will not work with older versions of the platform - it has to be deployed at the same time with the platform