### PR TITLE
More targering data

### DIFF
--- a/routes/adSlots.js
+++ b/routes/adSlots.js
@@ -455,7 +455,7 @@ async function getTargetingData(req, res) {
 				owner,
 				...rest,
 				// NOTE: this is per owner, no by slot
-				campaignsEarnedFrom: publishersWithRevenue[publishersWithRevenue],
+				campaignsEarnedFrom: publishersWithRevenue[owner],
 				types: Array.from(types),
 			}
 		})


### PR DESCRIPTION
* targeting-data:
  - removed filter by webshrinkerCategories for valid websites (need uncategorized to be available for exclusion with rules)
  - added `campaignsEarnedFrom` filed to result (used for some kind publisher validation instead impression count for the publisher slots)